### PR TITLE
getNode() in Scrollview fixes

### DIFF
--- a/ScrollableTabBar.js
+++ b/ScrollableTabBar.js
@@ -283,6 +283,16 @@ const ScrollableTabBar = createReactClass({
     );
   },
 
+  componentWillReceiveProps(nextProps) {
+    // If the tabs change, force the width of the tabs container to be recalculated
+    // if (
+    //   JSON.stringify(this.props.tabs) !== JSON.stringify(nextProps.tabs) &&
+    //   this.state._containerWidth
+    // ) {
+    //   this.setState({ _containerWidth: null });
+    // }
+  },
+
   onTabContainerLayout(e) {
     this._tabContainerMeasurements = e.nativeEvent.layout;
     let width = this._tabContainerMeasurements.width;

--- a/ScrollableTabBar.js
+++ b/ScrollableTabBar.js
@@ -283,16 +283,6 @@ const ScrollableTabBar = createReactClass({
     );
   },
 
-  componentWillReceiveProps(nextProps) {
-    // If the tabs change, force the width of the tabs container to be recalculated
-    if (
-      JSON.stringify(this.props.tabs) !== JSON.stringify(nextProps.tabs) &&
-      this.state._containerWidth
-    ) {
-      this.setState({ _containerWidth: null });
-    }
-  },
-
   onTabContainerLayout(e) {
     this._tabContainerMeasurements = e.nativeEvent.layout;
     let width = this._tabContainerMeasurements.width;

--- a/index.js
+++ b/index.js
@@ -31,7 +31,6 @@ const ScrollableTabView = createReactClass({
 		DefaultTabBar,
 		ScrollableTabBar,
 	},
-	scrollView : null,
 	scrollOnMountCalled: false,
 
 	propTypes: {
@@ -135,7 +134,6 @@ const ScrollableTabView = createReactClass({
 	},
 
 	goToPage(pageNumber) {
-		console.log("")
 		if (Platform.OS === 'ios') {
 			const offset = pageNumber * this.props.containerWidth
 			if (this.scrollView) {
@@ -143,7 +141,6 @@ const ScrollableTabView = createReactClass({
 					.scrollTo({ x: offset, y: 0, animated: !this.props.scrollWithoutAnimation })
 			}
 		} else if (this.scrollView) {
-			console.log("scrollview :" + this.scrollView);
 			if (this.props.scrollWithoutAnimation) {
 				this.scrollView.setPageWithoutAnimation(pageNumber)
 			} else {

--- a/index.js
+++ b/index.js
@@ -31,6 +31,7 @@ const ScrollableTabView = createReactClass({
 		DefaultTabBar,
 		ScrollableTabBar,
 	},
+	scrollView : null,
 	scrollOnMountCalled: false,
 
 	propTypes: {
@@ -134,18 +135,19 @@ const ScrollableTabView = createReactClass({
 	},
 
 	goToPage(pageNumber) {
+		console.log("")
 		if (Platform.OS === 'ios') {
 			const offset = pageNumber * this.props.containerWidth
 			if (this.scrollView) {
 				this.scrollView
-					.getNode()
 					.scrollTo({ x: offset, y: 0, animated: !this.props.scrollWithoutAnimation })
 			}
 		} else if (this.scrollView) {
+			console.log("scrollview :" + this.scrollView);
 			if (this.props.scrollWithoutAnimation) {
-				this.scrollView.getNode().setPageWithoutAnimation(pageNumber)
+				this.scrollView.setPageWithoutAnimation(pageNumber)
 			} else {
-				this.scrollView.getNode().setPage(pageNumber)
+				this.scrollView.setPage(pageNumber)
 			}
 		}
 


### PR DESCRIPTION
As in new version

this.scrollView.getNode().setPageWithoutAnimation(pageNumber)

Doesn't work and its fixed in new version as this.scrollView.setPageWithoutAnimation(pageNumber) in Android as well as iOS